### PR TITLE
Add SES domain identity ARN to output variables

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -50,3 +50,7 @@ output "ses_user_secret_access_key" {
   value     = module.ses.ses_user_secret_access_key
   sensitive = true
 }
+
+output "ses_domain_identity_arn" {
+  value = module.ses.ses_domain_identity_arn
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,3 +21,7 @@ output "ses_user_secret_access_key" {
   value     = try(aws_iam_access_key.ses_user[0].secret, null)
   sensitive = true
 }
+
+output "ses_domain_identity_arn" {
+  value = try(aws_ses_domain_identity.this.arn, null)
+}


### PR DESCRIPTION
There could be the necessity to reference the SES domain identity resource (e.g. we could send sign-up emails through SES using Cognito).