### PR TITLE
Add AWS region to CNAME records for DKIM tokens

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ resource "aws_route53_record" "cname" {
   name    = "${element(aws_ses_domain_dkim.this.0.dkim_tokens, count.index)}._domainkey.${var.domain}"
   type    = "CNAME"
   ttl     = "600"
-  records = ["${element(aws_ses_domain_dkim.this.0.dkim_tokens, count.index)}.dkim.amazonses.com"]
+  records = [format("${element(aws_ses_domain_dkim.this.0.dkim_tokens, count.index)}.dkim.%s.amazonses.com", var.aws_region)]
 }
 
 ## Create iam group and user.
@@ -126,7 +126,7 @@ module "daily_sending_quota_alarm" {
   alarm_actions = var.alarms.actions
 }
 
-# The percentage of emails sent from your account that resulted in recipients reporting them as spam 
+# The percentage of emails sent from your account that resulted in recipients reporting them as spam
 # based on a representative volume of email.
 module "reputation_complaint_rate_alarm" {
   source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"


### PR DESCRIPTION
The Confluence page that explains [how to send email using a custom domain through SES](https://pagopa.atlassian.net/l/cp/1001fYmp) says that to verify a custom domain, it is necessary to do that with some DNS records.

That document shows an example of the formato of those records:
```
...,
{
    "name" = "<...>._domainkey"
    "value" = "<...>.dkim.eu-south-1.amazonses.com"
},
...
```
those records contains the AWS region (e.g. `eu-south-1`) within the `value` field.

This terraform module, based on the input, can create those DNS records.
There is a small difference to let the module create the DNS records and the DOY approach:
if we are going to add the records manually (or creating resources with Terraform), we are going to use the value coming from the `outputs` (https://github.com/pagopa/terraform-aws-ses/blob/58c1263afa441692e67d1be5dca809e65d6852df/outputs.tf#L8-L14) and those tokens will contain the `aws_region` (https://github.com/pagopa/terraform-aws-ses/blob/58c1263afa441692e67d1be5dca809e65d6852df/outputs.tf#L11).

If we are letting the module create those records, those DNS records will not have the `aws_region` value within the DNS record. This will lead to some the issue that SES will not send email with a custom domain.

This PR should let this Terraform module to create properly the DNS records and solve the issues faced.