### PR TITLE
Implement DMARC TXT record creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ module "ses" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_daily_sending_quota_alarm"></a> [daily\_sending\_quota\_alarm](#module\_daily\_sending\_quota\_alarm) | terraform-aws-modules/cloudwatch/aws//modules/metric-alarm | ~> 3.0 |
-| <a name="module_reputation_bounce_rate_alarm"></a> [reputation\_bounce\_rate\_alarm](#module\_reputation\_bounce\_rate\_alarm) | terraform-aws-modules/cloudwatch/aws//modules/metric-alarm | ~> 3.0 |
-| <a name="module_reputation_complaint_rate_alarm"></a> [reputation\_complaint\_rate\_alarm](#module\_reputation\_complaint\_rate\_alarm) | terraform-aws-modules/cloudwatch/aws//modules/metric-alarm | ~> 3.0 |
+| <a name="module_aws_cloudwatch"></a> [aws\_cloudwatch](#module\_aws\_cloudwatch) | git::github.com/terraform-aws-modules/terraform-aws-cloudwatch | 36270f37e92c6996906bc671570afdef365eb9f3 |
+| <a name="module_daily_sending_quota_alarm"></a> [daily\_sending\_quota\_alarm](#module\_daily\_sending\_quota\_alarm) | ./.terraform/modules/aws_cloudwatch/modules/metric-alarm/ | n/a |
+| <a name="module_reputation_bounce_rate_alarm"></a> [reputation\_bounce\_rate\_alarm](#module\_reputation\_bounce\_rate\_alarm) | ./.terraform/modules/aws_cloudwatch/modules/metric-alarm/ | n/a |
+| <a name="module_reputation_complaint_rate_alarm"></a> [reputation\_complaint\_rate\_alarm](#module\_reputation\_complaint\_rate\_alarm) | ./.terraform/modules/aws_cloudwatch/modules/metric-alarm/ | n/a |
 
 ## Resources
 
@@ -53,6 +54,7 @@ module "ses" {
 | [aws_iam_group_policy.ses_group_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy) | resource |
 | [aws_iam_user.ses_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_route53_record.cname](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.dmarc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.txt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_ses_domain_dkim.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_domain_dkim) | resource |
 | [aws_ses_domain_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_domain_identity) | resource |
@@ -64,17 +66,18 @@ module "ses" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alarms"></a> [alarms](#input\_alarms) | n/a | <pre>object({<br>    daily_send_quota_threshold          = number<br>    daily_send_quota_period             = number<br>    reputation_complaint_rate_threshold = number<br>    reputation_complaint_rate_period    = number<br>    reputation_bounce_rate_threshold    = number<br>    reputation_bounce_rate_period       = number<br><br>    actions = list(string)<br>  })</pre> | `null` | no |
-| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | n/a | yes |
-| <a name="input_domain"></a> [domain](#input\_domain) | The domain name to assign to SES | `string` | n/a | yes |
-| <a name="input_iam_additional_statements"></a> [iam\_additional\_statements](#input\_iam\_additional\_statements) | Iam policy custom statements. | <pre>list(<br>    object({<br>      sid       = string<br>      actions   = list(string)<br>      resources = list(string)<br>    })<br>  )</pre> | `[]` | no |
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region. | `string` | n/a | yes |
+| <a name="input_dmarc_policy"></a> [dmarc\_policy](#input\_dmarc\_policy) | The DMARC (TXT) record to assign to domain. | `string` | `null` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | The domain name to assign to SES. | `string` | n/a | yes |
+| <a name="input_iam_additional_statements"></a> [iam\_additional\_statements](#input\_iam\_additional\_statements) | IAM policy custom statements. | <pre>list(<br>    object({<br>      sid       = string<br>      actions   = list(string)<br>      resources = list(string)<br>    })<br>  )</pre> | `[]` | no |
 | <a name="input_iam_allowed_resources"></a> [iam\_allowed\_resources](#input\_iam\_allowed\_resources) | Specifies resource ARNs that are enabled to send email. Wildcards are acceptable. | `list(string)` | `[]` | no |
-| <a name="input_iam_permissions"></a> [iam\_permissions](#input\_iam\_permissions) | Permission for the Iam user. | `list(string)` | <pre>[<br>  "ses:SendRawEmail"<br>]</pre> | no |
-| <a name="input_mail_from_subdomain"></a> [mail\_from\_subdomain](#input\_mail\_from\_subdomain) | Subdomain which is to be used as MAIL FROM address (Required for DMARC validation) | `string` | `null` | no |
+| <a name="input_iam_permissions"></a> [iam\_permissions](#input\_iam\_permissions) | Permission for the IAM user. | `list(string)` | <pre>[<br>  "ses:SendRawEmail"<br>]</pre> | no |
+| <a name="input_mail_from_subdomain"></a> [mail\_from\_subdomain](#input\_mail\_from\_subdomain) | Subdomain which is to be used as MAIL FROM address. | `string` | `null` | no |
 | <a name="input_ses_group_name"></a> [ses\_group\_name](#input\_ses\_group\_name) | The name of the IAM group to create. | `string` | n/a | yes |
-| <a name="input_ses_group_path"></a> [ses\_group\_path](#input\_ses\_group\_path) | The IAM Path of the group to create | `string` | `"/"` | no |
-| <a name="input_user_name"></a> [user\_name](#input\_user\_name) | SES Iam user name. If null no user and group will be created. | `string` | n/a | yes |
+| <a name="input_ses_group_path"></a> [ses\_group\_path](#input\_ses\_group\_path) | The IAM Path of the group to create. | `string` | `"/"` | no |
+| <a name="input_user_name"></a> [user\_name](#input\_user\_name) | SES IAM user name. If null no user and group will be created. | `string` | n/a | yes |
 | <a name="input_user_path"></a> [user\_path](#input\_user\_path) | Path in which to create the user. | `string` | `"/"` | no |
-| <a name="input_verify_dkim"></a> [verify\_dkim](#input\_verify\_dkim) | Verify dkim | `bool` | `true` | no |
+| <a name="input_verify_dkim"></a> [verify\_dkim](#input\_verify\_dkim) | Verify DKIM? | `bool` | `true` | no |
 | <a name="input_verify_domain"></a> [verify\_domain](#input\_verify\_domain) | Verify domain? | `bool` | `true` | no |
 | <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | R53 zone id. | `string` | `null` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -12,14 +12,24 @@ resource "aws_route53_record" "txt" {
   zone_id = var.zone_id
   name    = "_amazonses.${var.domain}"
   type    = "TXT"
-  ttl     = "600"
+  ttl     = "3600"
   records = [join("", aws_ses_domain_identity.this.*.verification_token)]
 }
 
-
 resource "aws_ses_domain_dkim" "this" {
-  count  = var.verify_domain ? 1 : 0
+  count = var.verify_domain ? 1 : 0
+
   domain = join("", aws_ses_domain_identity.this.*.domain)
+}
+
+resource "aws_route53_record" "dmarc" {
+  count = var.zone_id != null && var.dmarc_policy != null ? 1 : 0
+
+  zone_id = var.zone_id
+  name    = "_dmarc.${var.domain}"
+  type    = "TXT"
+  ttl     = "3600"
+  records = [var.dmarc_policy]
 }
 
 resource "aws_route53_record" "cname" {
@@ -28,11 +38,11 @@ resource "aws_route53_record" "cname" {
   zone_id = var.zone_id
   name    = "${element(aws_ses_domain_dkim.this.0.dkim_tokens, count.index)}._domainkey.${var.domain}"
   type    = "CNAME"
-  ttl     = "600"
+  ttl     = "3600"
   records = ["${element(aws_ses_domain_dkim.this.0.dkim_tokens, count.index)}.dkim.amazonses.com"]
 }
 
-## Create iam group and user.
+## Create IAM group and user.
 
 data "aws_iam_policy_document" "ses_policy" {
   count = var.user_name != null ? 1 : 0
@@ -52,8 +62,6 @@ data "aws_iam_policy_document" "ses_policy" {
       resources = statement.value.resources
     }
   }
-
-
 }
 
 resource "aws_iam_group" "ses_users" {
@@ -66,50 +74,55 @@ resource "aws_iam_group" "ses_users" {
 resource "aws_iam_group_policy" "ses_group_policy" {
   count = var.user_name != null ? 1 : 0
 
-  name  = join("", [var.ses_group_name, "Policy"])
-  group = aws_iam_group.ses_users[0].name
-
+  name   = join("", [var.ses_group_name, "Policy"])
+  group  = aws_iam_group.ses_users[0].name
   policy = join("", data.aws_iam_policy_document.ses_policy.*.json)
 }
 
 resource "aws_iam_user" "ses_user" {
   count = var.user_name != null ? 1 : 0
-  name  = var.user_name
-  path  = var.user_path
+
+  name = var.user_name
+  path = var.user_path
 }
 
 resource "aws_iam_group_membership" "ses_group" {
   count = var.user_name != null ? 1 : 0
-  name  = join("", [var.ses_group_name, "Membership"])
 
+  name = join("", [var.ses_group_name, "Membership"])
   users = [
     aws_iam_user.ses_user[0].name
   ]
-
   group = aws_iam_group.ses_users[0].name
 }
 
 
 resource "aws_iam_access_key" "ses_user" {
   count = var.user_name != null ? 1 : 0
-  user  = aws_iam_user.ses_user[0].name
+
+  user = aws_iam_user.ses_user[0].name
 }
 
 resource "aws_ses_domain_mail_from" "this" {
-  count            = var.mail_from_subdomain != null ? 1 : 0
+  count = var.mail_from_subdomain != null ? 1 : 0
+
   domain           = aws_ses_domain_identity.this.domain
   mail_from_domain = join(".", [var.mail_from_subdomain, aws_ses_domain_identity.this.domain])
 }
 
 ## Alarms
 
-### Sendign quotas
+module "aws_cloudwatch" {
+  # https://github.com/terraform-aws-modules/terraform-aws-cloudwatch/releases/tag/v3.3.0
+  source = "git::github.com/terraform-aws-modules/terraform-aws-cloudwatch?ref=36270f37e92c6996906bc671570afdef365eb9f3"
+}
+
+### Sending quotas
 
 module "daily_sending_quota_alarm" {
-  source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
-  version = "~> 3.0"
+  source = "./.terraform/modules/aws_cloudwatch/modules/metric-alarm/"
+  count  = var.alarms != null ? 1 : 0
 
-  count               = var.alarms != null ? 1 : 0
   alarm_name          = "ses-daily-sading-quota"
   actions_enabled     = true
   alarm_description   = "Daily usage approaching your sending limits."
@@ -118,21 +131,19 @@ module "daily_sending_quota_alarm" {
   threshold           = var.alarms.daily_send_quota_threshold
   period              = var.alarms.daily_send_quota_period
   unit                = "Count"
-
-  namespace   = "AWS/SES"
-  metric_name = "Send"
-  statistic   = "Sum"
-
-  alarm_actions = var.alarms.actions
+  namespace           = "AWS/SES"
+  metric_name         = "Send"
+  statistic           = "Sum"
+  alarm_actions       = var.alarms.actions
 }
 
+### Complaints
 # The percentage of emails sent from your account that resulted in recipients reporting them as spam 
 # based on a representative volume of email.
 module "reputation_complaint_rate_alarm" {
-  source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
-  version = "~> 3.0"
+  source = "./.terraform/modules/aws_cloudwatch/modules/metric-alarm/"
+  count  = var.alarms != null ? 1 : 0
 
-  count               = var.alarms != null ? 1 : 0
   alarm_name          = "ses-reputation-complaint-rate"
   actions_enabled     = true
   alarm_description   = "80% of emails sent from your account that resulted in recipients reporting them as spam."
@@ -144,16 +155,15 @@ module "reputation_complaint_rate_alarm" {
   namespace           = "AWS/SES"
   metric_name         = "Reputation.ComplaintRate"
   statistic           = "Average"
-
-  alarm_actions = var.alarms.actions
+  alarm_actions       = var.alarms.actions
 }
 
-### The percentage of emails sent from your account that resulted in a hard bounce based on a representative volume of email.
+### Hard bounces
+# The percentage of emails sent from your account that resulted in a hard bounce based on a representative volume of email.
 module "reputation_bounce_rate_alarm" {
-  source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
-  version = "~> 3.0"
+  source = "./.terraform/modules/aws_cloudwatch/modules/metric-alarm/"
+  count  = var.alarms != null ? 1 : 0
 
-  count               = var.alarms != null ? 1 : 0
   alarm_name          = "ses-reputation-bounce-rate"
   actions_enabled     = true
   alarm_description   = "10% of emails sent from your account that resulted in hard bounce."
@@ -162,10 +172,8 @@ module "reputation_bounce_rate_alarm" {
   threshold           = var.alarms.reputation_bounce_rate_threshold
   period              = var.alarms.reputation_bounce_rate_period
   unit                = "Count"
-
-  namespace   = "AWS/SES"
-  metric_name = "Reputation.BounceRate"
-  statistic   = "Average"
-
-  alarm_actions = var.alarms.actions
+  namespace           = "AWS/SES"
+  metric_name         = "Reputation.BounceRate"
+  statistic           = "Average"
+  alarm_actions       = var.alarms.actions
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,17 @@
 variable "aws_region" {
   type        = string
-  description = "AWS region"
+  description = "AWS region."
 }
 
 variable "domain" {
   type        = string
-  description = "The domain name to assign to SES"
+  description = "The domain name to assign to SES."
+}
+
+variable "dmarc_policy" {
+  type        = string
+  description = "The DMARC (TXT) record to assign to domain."
+  default     = null
 }
 
 variable "verify_domain" {
@@ -22,7 +28,7 @@ variable "zone_id" {
 
 variable "verify_dkim" {
   type        = bool
-  description = "Verify dkim"
+  description = "Verify DKIM?"
   default     = true
 }
 
@@ -31,7 +37,7 @@ variable "iam_permissions" {
   default = [
     "ses:SendRawEmail"
   ]
-  description = "Permission for the Iam user."
+  description = "Permission for the IAM user."
 }
 
 variable "iam_allowed_resources" {
@@ -49,7 +55,7 @@ variable "iam_additional_statements" {
     })
   )
   default     = []
-  description = "Iam policy custom statements."
+  description = "IAM policy custom statements."
 
 }
 
@@ -61,13 +67,13 @@ variable "ses_group_name" {
 
 variable "ses_group_path" {
   type        = string
-  description = "The IAM Path of the group to create"
+  description = "The IAM Path of the group to create."
   default     = "/"
 }
 
 variable "user_name" {
   type        = string
-  description = "SES Iam user name. If null no user and group will be created."
+  description = "SES IAM user name. If null no user and group will be created."
 }
 
 variable "user_path" {
@@ -78,7 +84,7 @@ variable "user_path" {
 
 variable "mail_from_subdomain" {
   type        = string
-  description = "Subdomain which is to be used as MAIL FROM address (Required for DMARC validation)"
+  description = "Subdomain which is to be used as MAIL FROM address."
   default     = null
 }
 


### PR DESCRIPTION
This PR is not particularly interesting for the new, optional, TXT record (DMARC policy), but rather for the attempt at pinning module versions through GitHub (and not through the Terraform Registry, which is not supported).

If validated, this will be our new standard across the org. Unfortunately this [cannot be a shallow git clone](https://developer.hashicorp.com/terraform/language/modules/sources#shallow-clone), so the idea is to reuse "locally" any already downloaded module (see source field).